### PR TITLE
docs: add a global FUNDING.yml for the org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+open_collective: yeoman


### PR DESCRIPTION
This move the `FUNDING.yml` ([ref](https://github.com/yeoman/yo/blob/main/.github/FUNDING.yml)) to the org level.

I will do a PR once this is merge to remove it from the individual repositories.